### PR TITLE
Changed to use mvnw not mvnw.cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM openjdk:14.0.2 as build
 WORKDIR /workspace/app
 
-COPY mvnw.cmd .
+COPY mvnw .
 COPY .mvn .mvn
 COPY pom.xml .
 COPY src src
 
-RUN ./mvnw.cmd install -DskipTests
+RUN ./mvnw install -DskipTests
 RUN mkdir -p target/dependency && (cd target/dependency; jar -xf ../*.jar)
 
 FROM openjdk:14.0.2


### PR DESCRIPTION
OpenJDK image is not windows based so when RUN mvnw.cmd was triggered in building the image, an error would occur. Pulling in the Linux/Mac OS wrapper mvnw and running that instead fixes the issue.