### PR TITLE
Fix to allow admin to view list of users in admin panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ build/
 
 ## upload-dir
 upload-dir/
+
+out/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,16 @@ services:
       dockerfile: ./Dockerfile
     image: "venus/beeple"
     network_mode: "host"
+    environment:
+      - MYSQL_USER=venus
+      - MYSQL_PASSWORD=pass
+      - MYSQL_DATABASE=jdbc:mysql://127.0.0.1:3306/venus
+      - SPRING_PROFILES_ACTIVE=prod
   venus-mysql:
     image: mysql:latest
     network_mode: "host"
     environment:
       - MYSQL_USER=venus
       - MYSQL_PASSWORD=pass
-      - MYSQL_DATABASE=jdbc:mysql://seng426-team3-mysql.mysql.database.azure.com:3306/venus
+      - MYSQL_ROOT_PASSWORD=pass
+      - MYSQL_DATABASE=venus

--- a/src/main/java/com/uvic/venus/controller/LoginController.java
+++ b/src/main/java/com/uvic/venus/controller/LoginController.java
@@ -52,7 +52,7 @@ public class LoginController {
     //UserRepository userRepository;
 
     @GetMapping
-    public Principal reteievePrincipal(Principal principal) {
+    public Principal retrievePrincipal(Principal principal) {
         return principal;
     }
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,13 +1,16 @@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=${env.MYSQL_DATABASE}
-spring.datasource.username=${env.MYSQL_USER}
-spring.datasource.password=${env.MYSQL_PASSWORD}
+spring.datasource.url=${MYSQL_DATABASE}
+spring.datasource.username=${MYSQL_USER}
+spring.datasource.password=${MYSQL_PASSWORD}
+spring.datasource.hikari.initialization-fail-timeout=30000
 
 # By default, Spring Boot initializes the data source only for embedded databases, which is not the case here:
 spring.sql.init.mode=always
 
 # Since we're not expecting Hibernate to create the schema now, we should disable the ddl-auto property
 spring.jpa.hibernate.ddl-auto=none
+spring.jpa.database=MYSQL
+spring.jpa.show-sql=false
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 


### PR DESCRIPTION
This fixes the behavior identified in https://github.com/seng426-team3/vega-spring/issues/34. Logged in admin users should be able to view the list of users now.