### PR TITLE
Fix to allow admin users to not enable already enabled users (#36)

### DIFF
--- a/src/main/java/com/uvic/venus/auth/JwtTokenFilter.java
+++ b/src/main/java/com/uvic/venus/auth/JwtTokenFilter.java
@@ -2,7 +2,6 @@ package com.uvic.venus.auth;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;

--- a/src/main/java/com/uvic/venus/collections/UserInfoCollection.java
+++ b/src/main/java/com/uvic/venus/collections/UserInfoCollection.java
@@ -1,0 +1,22 @@
+package com.uvic.venus.collections;
+
+import com.uvic.venus.model.UserInfo;
+
+public class UserInfoCollection {
+    
+    private Integer enabled;
+    private UserInfo userInfo;
+
+    public UserInfoCollection(Integer enabled, UserInfo userInfo) {
+        this.enabled = enabled;
+        this.userInfo = userInfo;
+    }
+
+    public Integer getEnabled() {
+        return enabled;
+    }
+
+    public UserInfo getUserInfo() {
+        return userInfo;
+    }
+}

--- a/src/main/java/com/uvic/venus/controller/AdminController.java
+++ b/src/main/java/com/uvic/venus/controller/AdminController.java
@@ -1,32 +1,28 @@
 package com.uvic.venus.controller;
 
+import com.uvic.venus.collections.UserInfoCollection;
 import com.uvic.venus.model.UserInfo;
+import com.uvic.venus.model.Users;
 import com.uvic.venus.repository.UserInfoDAO;
+import com.uvic.venus.repository.UsersDAO;
 import com.uvic.venus.storage.StorageService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.Resource;
-import org.springframework.data.repository.query.Param;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.JdbcUserDetailsManager;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/admin")
@@ -36,6 +32,9 @@ public class AdminController {
     UserInfoDAO userInfoDAO;
 
     @Autowired
+    UsersDAO usersDAO;
+
+    @Autowired
     DataSource dataSource;
 
     @Autowired
@@ -43,8 +42,22 @@ public class AdminController {
 
     @RequestMapping(value = "/fetchusers", method = RequestMethod.GET)
     public ResponseEntity<?> fetchAllUsers(){
+        // Return all userinfo attributes
         List<UserInfo> userInfoList = userInfoDAO.findAll();
-        return ResponseEntity.ok(userInfoList);
+        
+        // We return a collection of each user info and whether they
+        // are enabled or not.
+        List<UserInfoCollection> userInfoCollection = new ArrayList<>();
+        List<Users> usersList = usersDAO.findAll();
+        usersList.stream().forEach((user) -> {
+            userInfoList.stream().forEach((userinfo) -> {
+                if (user.getUsername().equals(userinfo.getUsername())) {
+                    userInfoCollection.add(new UserInfoCollection(user.getEnabled(), userinfo));
+                }
+            });
+        });
+
+        return ResponseEntity.ok(userInfoCollection);
     }
 
     @RequestMapping(value ="/enableuser", method = RequestMethod.GET)

--- a/src/main/java/com/uvic/venus/controller/FileController.java
+++ b/src/main/java/com/uvic/venus/controller/FileController.java
@@ -8,12 +8,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/uvic/venus/controller/LoginController.java
+++ b/src/main/java/com/uvic/venus/controller/LoginController.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.RestController;
 import javax.sql.DataSource;
 import java.security.Principal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/uvic/venus/model/Users.java
+++ b/src/main/java/com/uvic/venus/model/Users.java
@@ -1,0 +1,58 @@
+package com.uvic.venus.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name="users")
+public class Users {
+    
+    @Id
+    private String username;
+    private String password;
+    private Integer enabled;
+
+    public Users(String username, String password, Integer enabled) {
+        this.username = username;
+        this.password = password;
+        this.enabled = enabled;
+    }
+
+    public Users() {
+
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Integer getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Integer enabled) {
+        this.enabled = enabled;
+    }
+
+    @Override
+    public String toString() {
+        return "Users{" +
+                "username='" + username + '\'' +
+                ", password='" + password + '\'' +
+                ", enabled='" + enabled.toString() + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/uvic/venus/repository/UsersDAO.java
+++ b/src/main/java/com/uvic/venus/repository/UsersDAO.java
@@ -1,0 +1,10 @@
+package com.uvic.venus.repository;
+
+import com.uvic.venus.model.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UsersDAO extends JpaRepository<Users, String> {
+    
+}

--- a/src/main/java/com/uvic/venus/storage/StorageServiceImpl.java
+++ b/src/main/java/com/uvic/venus/storage/StorageServiceImpl.java
@@ -1,7 +1,6 @@
 package com.uvic.venus.storage;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -6,6 +6,7 @@ spring.datasource.hikari.initialization-fail-timeout=30000
 
 # By default, Spring Boot initializes the data source only for embedded databases, which is not the case here:
 spring.sql.init.mode=always
+spring.sql.init.platform=mysql
 
 # Since we're not expecting Hibernate to create the schema now, we should disable the ddl-auto property
 spring.jpa.hibernate.ddl-auto=none
@@ -13,6 +14,3 @@ spring.jpa.database=MYSQL
 spring.jpa.show-sql=false
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
-
-
-spring.sql.init.platform=mysql

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -6,11 +6,11 @@ INSERT INTO users (username, password, enabled) values
     ('jonoliver@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a',1),
     ('claudinezhang@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a',1),
     ('lovelinkumar@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a',1),
-    ('michelkouame@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a',1),
-    ('angelinacosta@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a',1),
+    ('michelkouame@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a',0),
+    ('angelinacosta@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a',0),
     ('brijeshgupta@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a',1),
-    ('amyfofana@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a',1),
-    ('testuser@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a', 1);
+    ('amyfofana@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a', 1),
+    ('testuser@venus.com', '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.AQubh4a', 0);
 
 
 


### PR DESCRIPTION
This is the spring side of the fix to issue 36, https://github.com/seng426-team3/vega-spring/issues/36 where admin have an option to enable users who are already enabled. This returns user data included whether they are already enabled or not.