### PR TITLE
Add role to userinfoCollection so data visible in vega-web

### DIFF
--- a/src/main/java/com/uvic/venus/collections/UserInfoCollection.java
+++ b/src/main/java/com/uvic/venus/collections/UserInfoCollection.java
@@ -5,18 +5,41 @@ import com.uvic.venus.model.UserInfo;
 public class UserInfoCollection {
     
     private Integer enabled;
+    private String role;
     private UserInfo userInfo;
+
+    public UserInfoCollection(Integer enabled, String role, UserInfo userInfo) {
+        this.enabled = enabled;
+        this.role = role;
+        this.userInfo = userInfo;
+    }
 
     public UserInfoCollection(Integer enabled, UserInfo userInfo) {
         this.enabled = enabled;
-        this.userInfo = userInfo;
+        this.userInfo = userInfo;       
     }
 
     public Integer getEnabled() {
         return enabled;
     }
 
+    public void setEnabled(Integer enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
     public UserInfo getUserInfo() {
         return userInfo;
+    }
+
+    public void setUserInfo(UserInfo userInfo) {
+        this.userInfo = userInfo;
     }
 }

--- a/src/main/java/com/uvic/venus/controller/AdminController.java
+++ b/src/main/java/com/uvic/venus/controller/AdminController.java
@@ -1,8 +1,10 @@
 package com.uvic.venus.controller;
 
 import com.uvic.venus.collections.UserInfoCollection;
+import com.uvic.venus.model.Authorities;
 import com.uvic.venus.model.UserInfo;
 import com.uvic.venus.model.Users;
+import com.uvic.venus.repository.AuthoritiesDAO;
 import com.uvic.venus.repository.UserInfoDAO;
 import com.uvic.venus.repository.UsersDAO;
 import com.uvic.venus.storage.StorageService;
@@ -35,6 +37,9 @@ public class AdminController {
     UsersDAO usersDAO;
 
     @Autowired
+    AuthoritiesDAO authoritiesDAO;
+
+    @Autowired
     DataSource dataSource;
 
     @Autowired
@@ -44,6 +49,7 @@ public class AdminController {
     public ResponseEntity<?> fetchAllUsers(){
         // Return all userinfo attributes
         List<UserInfo> userInfoList = userInfoDAO.findAll();
+        List<Authorities> authoritiesList = authoritiesDAO.findAll();
         
         // We return a collection of each user info and whether they
         // are enabled or not.
@@ -53,6 +59,16 @@ public class AdminController {
             userInfoList.stream().forEach((userinfo) -> {
                 if (user.getUsername().equals(userinfo.getUsername())) {
                     userInfoCollection.add(new UserInfoCollection(user.getEnabled(), userinfo));
+                }
+            });
+        });
+
+        // We add the user's role to the list as well.
+        userInfoCollection.stream().forEach((userInfo) -> {
+            authoritiesList.stream().forEach((authority) -> {
+                if (authority.getUsername().equals(userInfo.getUserInfo().getUsername())) {
+                    // The authority entry is equivalent to the role semantics on vega-web
+                    userInfo.setRole(authority.getAuthority());
                 }
             });
         });

--- a/src/main/java/com/uvic/venus/model/Authorities.java
+++ b/src/main/java/com/uvic/venus/model/Authorities.java
@@ -1,0 +1,47 @@
+package com.uvic.venus.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name="authorities")
+public class Authorities {
+    
+    @Id
+    private String username;
+    private String authority;
+
+    public Authorities(String username, String authority) {
+        this.username = username;
+        this.authority = authority;
+    }
+
+    public Authorities() {
+
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getAuthority() {
+        return authority;
+    }
+
+    public void setAuthority(String authority) {
+        this.authority = authority;
+    }
+
+    @Override
+    public String toString() {
+        return "Authorities{" +
+                "username='" + username + '\'' +
+                ", authority='" + authority + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/uvic/venus/repository/AuthoritiesDAO.java
+++ b/src/main/java/com/uvic/venus/repository/AuthoritiesDAO.java
@@ -1,0 +1,9 @@
+package com.uvic.venus.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import com.uvic.venus.model.Authorities;
+
+@Repository
+public interface AuthoritiesDAO extends JpaRepository<Authorities, String> {
+}


### PR DESCRIPTION
Edited the UserInfoCollection so that the user's role is returned in vega-web in the admin panel. This is used to prevent the admin from changing their own role.